### PR TITLE
Documentation, Bugfix, Formatting & Grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ vault.exe audit enable file file_path=\\server.domain.tld\share\vault_audit_logs
 ```
 
 In this example:
-1. Although not explicitly shown, we rely on and import the `CredentialManager` module.
+1. Although not explicitly shown, this example relies on and imports the `CredentialManager` module.
 2. We define a `TemporaryTokenLocation` and a `VAULT_ADDR` and then use the temporary token to retrieve the wrapped token.
 3. We attempt to get an existing renewable token from the CredentialManager and then check that it is valid (not expired) in Vault. We assign that value, if it exists, to `$global:VAULT_TOKEN`.
 4. We switch on TRUE over four cases:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 psVaultUtils is a module for interacting with Hashicorp Vault.
 
 # Author
-Ben Small <bsmall@wayfair.com>
+Ben Small `bsmall[at]wayfair.com`
 
 ## Author's Note
 This is my first open source project. Please bear with me while I stumble through the proper way to manage branches and perform pull requests when external parties are involved. Thank you for your patience.
@@ -220,7 +220,7 @@ auth           : @{client_token=s.tOZMiBe0WkpZ4NeUCXKdrvVA; accessor=kQdhTOrp5IE
 ```powershell
 PS> $newTokenParams = @{
 >>      RoleName = 'SomeRole'
->>      Policies = 'jenkinsc02-secret-consumer'
+>>      Policies = 'jenkins-secret-consumer'
 >>      MetaData = @{ 'user'='ben.small' }
 >>      Renewable = $true
 >>      TimeToLive = "48h"
@@ -600,13 +600,13 @@ vault.exe audit enable file file_path=\\server.domain.tld\share\vault_audit_logs
 ```
 
 In this example:
-0. Although not explicitly shown, we rely on and import the `CredentialManager` module.
-1. We define a `TemporaryTokenLocation` and a `VAULT_ADDR` and then use the temporary token to retrieve the wrapped token.
-2. We attempt to get an existing renewable token from the CredentialManager and then check that it is valid (not expired) in Vault. We assign that value, if it exists, to `$global:VAULT_TOKEN`.
-3. We switch on TRUE over four cases:
+1. Although not explicitly shown, we rely on and import the `CredentialManager` module.
+2. We define a `TemporaryTokenLocation` and a `VAULT_ADDR` and then use the temporary token to retrieve the wrapped token.
+3. We attempt to get an existing renewable token from the CredentialManager and then check that it is valid (not expired) in Vault. We assign that value, if it exists, to `$global:VAULT_TOKEN`.
+4. We switch on TRUE over four cases:
     1. Case where the wrapping token is valid and an existing token lives in the credential manager. In this scenario we overwrite the new unwrapped token with the one that lives in the CredentialManager.
     2. Case where the wrapped token has already been retrieved once and an existing token already exists. In this scenario we attempt to renew the existing token. Conditional logic exists to report a failure if the token cannot be renewed.
     3. Case where the wrapping token is valid and there is no existing token in the CredentialManager; In this scenario we add the wrapped token to the CredentialManager Vault.
     4. Case where the wrapping token is invalid (has been used) and there is no valid, existing token in the CredentialManager. In this scenario the token may have been tampered with. Logic can be written to alert on this scenario.
-4. Provided that we've hit cases 1, 2 or 3, we can proceed to re-acquire the new/renewed "permanent" token from the CredentialManager. 
-5. We then use the token to disable and re-enable the Vault Audit Log Device "File".
+5. Provided that we've hit cases 1, 2 or 3, we can proceed to re-acquire the new/renewed "permanent" token from the CredentialManager. 
+6. We then use the token to disable and re-enable the Vault Audit Log Device "File".

--- a/psVaultUtils/Public/RootTokens/Get-VaultRootTokenGenerationProgress.ps1
+++ b/psVaultUtils/Public/RootTokens/Get-VaultRootTokenGenerationProgress.ps1
@@ -43,7 +43,7 @@ function Get-VaultRootTokenGenerationProgress {
 #>
     [CmdletBinding()]
     param(
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 0
         )]

--- a/psVaultUtils/Public/RootTokens/Start-VaultRootTokenGeneration.ps1
+++ b/psVaultUtils/Public/RootTokens/Start-VaultRootTokenGeneration.ps1
@@ -32,7 +32,7 @@ function Start-VaultRootTokenGeneration {
         [ValidateScript({ $_ -match "^[a-zA-Z0-9\+/]*={0,2}$" })]
         [String] $PGPKey,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/RootTokens/Submit-VaultRootTokenGeneration.ps1
+++ b/psVaultUtils/Public/RootTokens/Submit-VaultRootTokenGeneration.ps1
@@ -52,7 +52,7 @@ Please provide a single Unseal Key: ********************************************
         )]
         [String] $Nonce,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/RootTokens/Unprotect-VaultRootToken.ps1
+++ b/psVaultUtils/Public/RootTokens/Unprotect-VaultRootToken.ps1
@@ -29,7 +29,7 @@ function Unprotect-VaultRootToken {
 
         [String] $Otp,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/SecretEngines/Get-VaultKVEngine.ps1
+++ b/psVaultUtils/Public/SecretEngines/Get-VaultKVEngine.ps1
@@ -35,7 +35,7 @@ function Get-VaultKVEngine {
         )]
         [String] $Engine,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/Secrets/Cubbyhole/Get-VaultCubbyholeSecret.ps1
+++ b/psVaultUtils/Public/Secrets/Cubbyhole/Get-VaultCubbyholeSecret.ps1
@@ -37,7 +37,7 @@ function Get-VaultCubbyholeSecret {
         )]
         [String] $SecretsPath,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/Secrets/KV/Get-VaultKVSecret.ps1
+++ b/psVaultUtils/Public/Secrets/KV/Get-VaultKVSecret.ps1
@@ -80,7 +80,7 @@ function Get-VaultKVSecret {
         )]
         [Switch] $MetaData,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 3
         )]

--- a/psVaultUtils/Public/Secrets/KV/New-VaultKVSecret.ps1
+++ b/psVaultUtils/Public/Secrets/KV/New-VaultKVSecret.ps1
@@ -84,7 +84,7 @@ function New-VaultKVSecret {
         [ValidateScript({ $_ -gt 0 })]
         [Int] $CheckAndSet,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 4
         )]

--- a/psVaultUtils/Public/Server-Key/Get-VaultKeyStatus.ps1
+++ b/psVaultUtils/Public/Server-Key/Get-VaultKeyStatus.ps1
@@ -23,7 +23,7 @@ function Get-VaultKeyStatus {
 #>
     [CmdletBinding()]
     param(
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 0
         )]

--- a/psVaultUtils/Public/Server-Key/Get-VaultRekeyProgress.ps1
+++ b/psVaultUtils/Public/Server-Key/Get-VaultRekeyProgress.ps1
@@ -40,7 +40,7 @@ function Get-VaultRekeyProgress {
 #>
     [CmdletBinding()]
     param(
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 0
         )]

--- a/psVaultUtils/Public/Server-Key/Get-VaultRekeyVerificationProgress.ps1
+++ b/psVaultUtils/Public/Server-Key/Get-VaultRekeyVerificationProgress.ps1
@@ -28,7 +28,7 @@ function Get-VaultRekeyVerificationProgress {
 #>
     [CmdletBinding()]
     param(
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 0
         )]

--- a/psVaultUtils/Public/Server-Key/Submit-VaultRekey.ps1
+++ b/psVaultUtils/Public/Server-Key/Submit-VaultRekey.ps1
@@ -59,7 +59,7 @@ function Submit-VaultRekey {
         )]
         [String] $Nonce,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/Server-Key/Submit-VaultRekeyVerification.ps1
+++ b/psVaultUtils/Public/Server-Key/Submit-VaultRekeyVerification.ps1
@@ -45,7 +45,7 @@ function Submit-VaultRekeyVerification {
         )]
         [String] $Nonce,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/Server/Get-VaultMetric.ps1
+++ b/psVaultUtils/Public/Server/Get-VaultMetric.ps1
@@ -39,7 +39,7 @@ function Get-VaultMetric {
         DefaultParameterSetName = 'All'
     )]
     param(
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 0
         )]

--- a/psVaultUtils/Public/Server/Get-VaultStatus.ps1
+++ b/psVaultUtils/Public/Server/Get-VaultStatus.ps1
@@ -40,7 +40,7 @@ function Get-VaultStatus {
 #>
     [CmdletBinding()]
     param(
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 0
         )]

--- a/psVaultUtils/Public/Server/Test-VaultHealth.ps1
+++ b/psVaultUtils/Public/Server/Test-VaultHealth.ps1
@@ -43,7 +43,7 @@ function Test-VaultHealth {
         )]
         [String] $VaultNodeOverride,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 2
         )]

--- a/psVaultUtils/Public/Server/Unprotect-Vault.ps1
+++ b/psVaultUtils/Public/Server/Unprotect-Vault.ps1
@@ -76,7 +76,7 @@ DYNAMIC PARAMETERS
         )]
         [String] $VaultNodeOverride,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 2
         )]

--- a/psVaultUtils/Public/Tokens/Get-VaultLoginToken.ps1
+++ b/psVaultUtils/Public/Tokens/Get-VaultLoginToken.ps1
@@ -40,7 +40,7 @@ function Get-VaultLoginToken {
         DefaultParameterSetName = 'AllData'
     )]
     param(
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 0
         )]

--- a/psVaultUtils/Public/Tokens/Get-VaultToken.ps1
+++ b/psVaultUtils/Public/Tokens/Get-VaultToken.ps1
@@ -94,7 +94,7 @@ function Get-VaultToken {
         )]
         [Switch] $Self,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 2
         )]

--- a/psVaultUtils/Public/Tokens/Get-VaultTokenAccessor.ps1
+++ b/psVaultUtils/Public/Tokens/Get-VaultTokenAccessor.ps1
@@ -68,7 +68,7 @@ function Get-VaultTokenAccessor {
         )]
         $Accessor,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/Tokens/New-VaultToken.ps1
+++ b/psVaultUtils/Public/Tokens/New-VaultToken.ps1
@@ -201,7 +201,7 @@ function New-VaultToken {
         )]
         [Switch] $Orphan,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 13
         )]

--- a/psVaultUtils/Public/Tokens/New-VaultWrappedToken.ps1
+++ b/psVaultUtils/Public/Tokens/New-VaultWrappedToken.ps1
@@ -45,7 +45,7 @@ function New-VaultWrappedToken {
         )]
         [String[]] $WrapPolicies,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 2
         )]

--- a/psVaultUtils/Public/Tokens/Update-VaultToken.ps1
+++ b/psVaultUtils/Public/Tokens/Update-VaultToken.ps1
@@ -88,7 +88,7 @@ function Update-VaultToken {
         [ValidateScript({ $_ -match "^\d+$|^\d+[smh]$" })]
         [String] $Increment,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 3
         )]

--- a/psVaultUtils/Public/Tools/Get-VaultDataHash.ps1
+++ b/psVaultUtils/Public/Tools/Get-VaultDataHash.ps1
@@ -48,7 +48,7 @@ function Get-VaultDataHash {
         [ValidateSet('Base64','Hex')]
         [String] $Format = 'Base64',
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 3
         )]

--- a/psVaultUtils/Public/Tools/Get-VaultRandomBytes.ps1
+++ b/psVaultUtils/Public/Tools/Get-VaultRandomBytes.ps1
@@ -51,7 +51,7 @@ function Get-VaultRandomBytes {
         [ValidateSet('Base64','Hex')]
         [String] $Format = 'Base64',
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 2
         )]

--- a/psVaultUtils/Public/Wrapping/Get-VaultWrapping.ps1
+++ b/psVaultUtils/Public/Wrapping/Get-VaultWrapping.ps1
@@ -49,7 +49,7 @@ function Get-VaultWrapping {
         )]
         [Switch] $IsWrappingToken,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 2
         )]

--- a/psVaultUtils/Public/Wrapping/New-VaultWrapping.ps1
+++ b/psVaultUtils/Public/Wrapping/New-VaultWrapping.ps1
@@ -53,7 +53,7 @@ function New-VaultWrapping {
         [ValidateScript({ $_ -match "^\d+$|^\d+[smh]$" })]
         [String] $WrapTTL = "24h",
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 2
         )]

--- a/psVaultUtils/Public/Wrapping/Show-VaultWrapping.ps1
+++ b/psVaultUtils/Public/Wrapping/Show-VaultWrapping.ps1
@@ -29,7 +29,7 @@ function Show-VaultWrapping {
         )]
         [String] $Token,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/Public/Wrapping/Update-VaultWrapping.ps1
+++ b/psVaultUtils/Public/Wrapping/Update-VaultWrapping.ps1
@@ -31,7 +31,7 @@ function Update-VaultWrapping {
         )]
         [String] $Token,
 
-        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        #Specifies how output information should be displayed in the console. Available options are JSON, PSObject or Hashtable.
         [Parameter(
             Position = 1
         )]

--- a/psVaultUtils/psVaultUtils.psd1
+++ b/psVaultUtils/psVaultUtils.psd1
@@ -12,7 +12,7 @@
     RootModule = 'psVaultUtils.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.4.2'
+    ModuleVersion = '1.4.3'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/wayfair.yml
+++ b/wayfair.yml
@@ -1,6 +1,0 @@
-version: '0'
-owners:
-    technical:
-        - bsmall:bsmall
-        - rorlov:rorlov
-        - jpope:jpope


### PR DESCRIPTION
- Replaces Invoke-Expression calls in Format-VaultOutput with Invoke-Command. Replaces expressions with ScriptBlocks.
- Fixes a formatting issue in the README.
- Replaces bsmall email address with anti-bot email address formatting.
- Generalizes a reference to an actual KV engine.
- Fixes parameter help for OutputType across ~28 ish functions.
- Increments the version of the module.
- Resolves #2 
- Resolves #3 