### PR TITLE
Show/List Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 
 ## Unreleased
 
+### 1.6.0
+* Adds support for functions that query Vault API endpoints that utilize the LIST method.
+  * Adds Show-VaultTokenAccessor, a command that lists all active token accessors.
+  * Adds Show-VaultKVSecret, a command presents a list of key names at a specified Vault secret path.
+* Updates the README with information noting the Invoke-RestMethod limitation of not having a LIST method.
+* Updates the README with information about the Show --> List aliasing.
+* Updates the module manifest with new functions and aliases.
+* Fixes a bug in Format-VaultOutput introduced in v1.5.1.
+
 ### 1.5.1
 * Adds functions for listing, getting, updating, creating and deleting policies.
 * Adds a function for generating policy documents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### 1.6.0
 * Adds support for functions that query Vault API endpoints that utilize the LIST method.
   * Adds Show-VaultTokenAccessor, a command that lists all active token accessors.
-  * Adds Show-VaultKVSecret, a command presents a list of key names at a specified Vault secret path.
+  * Adds Show-VaultKVSecret, a command that presents a list of key names at a specified Vault secret path.
 * Updates the README with information noting the Invoke-RestMethod limitation of not having a LIST method.
 * Updates the README with information about the Show --> List aliasing.
 * Updates the module manifest with new functions and aliases.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ This is my first open source project. Please bear with me while I stumble throug
 * Sets of functions to interact with engines other than _KV_ and _Cubbyhole_ are not currently present.
 * Sets of functions and/or parameters to interact with _enterprise features_ are generally not present.
 
+## Other Limitiations
+* PowerShell 5.1 Invoke-RestMethod does not support the LIST method, which is used by some Vault API endpoints. 
+    * This can be worked around by specifying `-Method GET -Body @{ list = 'true' }` in an Invoke-RestMethod call.
+
+# To-Do / Open Questions
+
+## To-Do
+
+## Questions
+* Is `Show-` the appropriate verb for listing data?
+    * `Show-VaultKVSecret` lists the secret keys given a specified path, while `Get-VaultKVSecret` gets a specific secret.
+    * `Show-VaultWrapping` lists the wrapped secrets available to a token, while `Get-VaultWrapping` unwraps the secrets.
+
 # Verb Mapping // Command Aliases
 
 Hashicorp Vault uses several "verbs", which, according to PowerShell standards are considered unapproved, and make commands less discoverable. 
@@ -63,6 +76,15 @@ The following verb mappings and command alises might actually make a person who 
 * Stop-VaultRekeyVerification --> Cancel-VaultRekeyVerification
 * Stop-VaultRootTokenGeneration --> Cancel-VaultRootTokenGeneration
 * Update-VaultToken --> Renew-VaultToken
+
+## Secret / Token / Accessor Verbs & Command Aliases
+
+* List --> Show
+
+<br>
+
+* Show-VaultKVSecret --> List-VaultKVSecret
+* Show-VaultTokenAccessor --> List-VaultTokenAccessor
 
 # Command Usage
 

--- a/psVaultUtils/Private/Format-VaultOutput.ps1
+++ b/psVaultUtils/Private/Format-VaultOutput.ps1
@@ -129,6 +129,10 @@ function Format-VaultOutput {
                 'policy_data' {
                     $expression = '$InputObject.data | Select-Object policies'
                 }
+
+                'policy_data' {
+                    $expression = '$InputObject.data | Select-Object policies'
+                }
             }
     
             switch ($OutputType) {

--- a/psVaultUtils/Private/Format-VaultOutput.ps1
+++ b/psVaultUtils/Private/Format-VaultOutput.ps1
@@ -127,11 +127,7 @@ function Format-VaultOutput {
                 }
 
                 'policy_data' {
-                    $expression = '$InputObject.data | Select-Object policies'
-                }
-
-                'policy_data' {
-                    $expression = '$InputObject.data | Select-Object policies'
+                    $command = { $InputObject.data | Select-Object 'policies' }
                 }
             }
     

--- a/psVaultUtils/Public/Secrets/KV/Show-VaultKVSecret.ps1
+++ b/psVaultUtils/Public/Secrets/KV/Show-VaultKVSecret.ps1
@@ -1,0 +1,108 @@
+function Show-VaultKVSecret {
+<#
+.Synopsis
+    Retrieves a list of key names at a specified Vault secrets path.
+
+.DESCRIPTION
+    Show-VaultKVSecret is capable of retrieving a list of key names given a specified vault secrets path.
+
+    Folders are suffixed with "/".
+    The input must be a folder; LIST on a file will not return a value.
+
+    Note that no policy-based filtering is performed on keys; do not encode sensitive information in key names. 
+    The values themselves are not accessible via this command.
+
+.EXAMPLE
+    PS> Show-VaultKVSecret -Engine dsc -SecretsPath SQLAG -OutputType PSObject -JustData | Select-Object -ExpandProperty keys
+
+    conf_ag/
+    hp_ag/
+    mbam_ag/
+    pwst_ag/
+    rdw_ag/
+
+.EXAMPLE
+    PS> Show-VaultKVSecret -Engine dsc -SecretsPath SQLAG/conf_ag -OutputType PSObject
+
+    request_id     : 19887baa-35ff-5722-ed7c-4f08a4c638d3
+    lease_id       :
+    renewable      : False
+    lease_duration : 0
+    data           : @{keys=System.Object[]}
+    wrap_info      :
+    warnings       :
+    auth           :
+
+#>
+    [CmdletBinding()]
+    param(
+        #Specifies a KV engine to retrieve secret keys from.
+        [Parameter(
+            Mandatory = $true,
+            Position = 0
+        )]
+        [String] $Engine,
+
+        #Specifies the secrets path to retrieve secret keys from.
+        [Parameter(
+            Mandatory = $true,
+            Position = 1
+        )]
+        [String] $SecretsPath,
+
+        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        [Parameter(
+            Position = 2
+        )]
+        [ValidateSet('Json','PSObject','Hashtable')]
+        [String] $OutputType = 'PSObject',
+
+        #Specifies whether or not just the data should be displayed in the console.
+        [Parameter(
+            Position = 3
+        )]
+        [Switch] $JustData
+    )
+
+    begin {
+        Test-VaultSessionVariable -CheckFor 'Address','Token'
+    }
+
+    process {
+        $uri = $global:VAULT_ADDR
+
+        #This API Endpoint requires the use of the LIST method; Invoke-RestMethod does not natively support the LIST method.
+        #Custom REST Methods are introduced in the PowerShell Core version of Invoke-RestMethod. 
+        #Adding list = true to the query parameters (body) allows us to work around this limitation.
+        $body = @{ list = 'true' }
+
+        $irmParams = @{
+            Uri    = "$uri/v1/$Engine/metadata/$SecretsPath"
+            Header = @{ "X-Vault-Token" = $global:VAULT_TOKEN }
+            Method = 'Get'
+            Body   = $body
+        }
+
+        try {
+            $result = Invoke-RestMethod @irmParams
+        }
+        catch {
+            throw
+        }
+
+        $formatParams = @{
+            InputObject = $result
+            DataType    = 'secret_metadata'
+            JustData    = $JustData.IsPresent
+            OutputType  = $OutputType
+        }
+
+        Format-VaultOutput @formatParams
+    }
+
+    end {
+
+    }
+}
+
+Set-Alias -Name 'List-VaultKVSecret' -Value 'Show-VaultKVSecret'

--- a/psVaultUtils/Public/Tokens/Show-VaultTokenAccessor.ps1
+++ b/psVaultUtils/Public/Tokens/Show-VaultTokenAccessor.ps1
@@ -1,0 +1,132 @@
+function Show-VaultTokenAccessor {
+<#
+.Synopsis
+    Retrieves accessors for all active tokens.
+
+.DESCRIPTION
+    Show-VaultTokenAccessor retrieves accessors for all active tokens.
+
+    This function requires 'sudo' capabilities over the path 'auth/token/accessors'.
+
+.EXAMPLE
+    PS> Show-VaultTokenAccessor -JustData | Select-Object -ExpandProperty Keys
+
+    qfOMvaE16JzygFyIcZxSy56j
+    6AwiRrQfXIjebiSj96NeROSE
+    3ikBVLk56KGqBwhBAtFX2VQu
+    tSupKG3HmzXn5u0svx41YQDs
+    uPNDSjq2zr36eWVNLEPHyof5
+    VhLGl4GhSVDxaXDYOX17b3zx
+    ze9Nb2M0RMBbqTTlGg4Qu8yI
+    riPvcYB9Q6OvB9af1xt1NU5h
+    ZvdNE1kwNqdbhzZYUDVQKZms
+    LQ3TWNj5GTVfLJdFnww6Vwlg
+
+.EXAMPLE 
+    PS> Show-VaultTokenAccessor -OutputType json
+    {
+        "request_id":  "bdb76999-035b-0d10-3dd3-e140c25d8d1c",
+        "lease_id":  "",
+        "renewable":  false,
+        "lease_duration":  0,
+        "data":  {
+                    "keys":  [
+                                "qfOMvaE16JzygFyIcZxSy56j",
+                                "6AwiRrQfXIjebiSj96NeROSE",
+                                "3ikBVLk56KGqBwhBAtFX2VQu",
+                                "tSupKG3HmzXn5u0svx41YQDs",
+                                "uPNDSjq2zr36eWVNLEPHyof5",
+                                "VhLGl4GhSVDxaXDYOX17b3zx",
+                                "ze9Nb2M0RMBbqTTlGg4Qu8yI",
+                                "riPvcYB9Q6OvB9af1xt1NU5h",
+                                "ZvdNE1kwNqdbhzZYUDVQKZms",
+                                "LQ3TWNj5GTVfLJdFnww6Vwlg"
+                            ]
+                },
+        "wrap_info":  null,
+        "warnings":  null,
+        "auth":  null
+    }
+
+.EXAMPLE
+    PS> Show-VaultTokenAccessor -JustData | Select-Object -ExpandProperty keys | Select-Object -First 1 | Get-VaultTokenAccessor -JustData
+
+    accessor                    : qfOMvaE16JzygFyIcZxSy56j
+    creation_time               : 1566502364
+    creation_ttl                : 86400
+    display_name                : ldap-dev-ben-small
+    entity_id                   : 357f788d-75cf-c16d-f6d9-cdbd6c5deee8
+    expire_time                 : 2019-08-23T15:32:44.5664492-04:00
+    explicit_max_ttl            : 0
+    external_namespace_policies :
+    id                          :
+    identity_policies           : {jenkins-secret-consumer, operator}
+    issue_time                  : 2019-08-22T15:32:44.5664492-04:00
+    meta                        : @{username=dev-ben-small}
+    num_uses                    : 0
+    orphan                      : True
+    path                        : auth/ldap/login/dev-ben-small
+    policies                    : {default}
+    renewable                   : True
+    ttl                         : 25288
+    type                        : service
+
+
+    This example demonstrates retrieving all of the active accessors, selecting the first one and then sending it down the pipeline to have its properties retrieved.
+
+#>
+    [CmdletBinding()]
+    param(
+        #Specifies how output information should be displayed in the console. Available options are JSON or PSObject.
+        [Parameter(
+            Position = 0
+        )]
+        [ValidateSet('Json','PSObject','Hashtable')]
+        [String] $OutputType = 'PSObject',
+
+        #Specifies whether or not just the token accessor data should be displayed in the console.
+        [Parameter(
+            Position = 1
+        )]
+        [Switch] $JustData
+    )
+
+    begin {
+        Test-VaultSessionVariable -CheckFor 'Address','Token'
+    }
+
+    process {
+        $uri = $global:VAULT_ADDR
+        
+        $body = @{ list = 'true' }
+
+        $irmParams = @{
+            Uri    = "$uri/v1/auth/token/accessors"
+            Header = @{ "X-Vault-Token" = $global:VAULT_TOKEN }
+            Body   = $body
+            Method = 'Get'
+        }
+
+        try {
+            $result = Invoke-RestMethod @irmParams
+        }
+        catch {
+            throw
+        }
+
+        $formatParams = @{
+            InputObject = $result
+            DataType    = 'data'
+            JustData    = $JustData.IsPresent
+            OutputType  = $OutputType
+        }
+
+        Format-VaultOutput @formatParams
+    }
+
+    end {
+
+    }
+}
+
+Set-Alias -Name 'List-VaultTokenAccessor' -Value 'Show-VaultTokenAccessor'

--- a/psVaultUtils/psVaultUtils.psd1
+++ b/psVaultUtils/psVaultUtils.psd1
@@ -166,7 +166,6 @@
 
         'List-VaultPolicy'
         
-        
         'List-VaultKVSecret'
         'List-VaultTokenAccessor'
     )

--- a/psVaultUtils/psVaultUtils.psd1
+++ b/psVaultUtils/psVaultUtils.psd1
@@ -4,7 +4,7 @@
     RootModule = 'psVaultUtils.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.5.1'
+    ModuleVersion = '1.6.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/psVaultUtils/psVaultUtils.psd1
+++ b/psVaultUtils/psVaultUtils.psd1
@@ -95,14 +95,16 @@
         'Get-VaultLoginToken'
         'Set-VaultLoginToken'
 
+        'Get-VaultToken'
         'New-VaultToken'
         'New-VaultWrappedToken'
-        'Get-VaultToken'
-        'Update-VaultToken'
         'Revoke-VaultToken'
+        'Show-VaultTokenRole'
+        'Update-VaultToken'
 
         'Get-VaultTokenAccessor'
         'Revoke-VaultTokenAccessor'
+        'Show-VaultTokenAccessor'
 
         'Get-VaultRootTokenGenerationProgress'
         'Start-VaultRootTokenGeneration'
@@ -121,6 +123,7 @@
         'Get-VaultKVSecret'
         'Remove-VaultKVSecret'
         'Restore-VaultKVSecret'
+        'Show-VaultKVSecret'
 
         'New-VaultCubbyholeSecret'
         'Get-VaultCubbyholeSecret'
@@ -162,6 +165,10 @@
         'Renew-VaultToken'
 
         'List-VaultPolicy'
+        
+        
+        'List-VaultKVSecret'
+        'List-VaultTokenAccessor'
     )
     
     # DSC resources to export from this module

--- a/psVaultUtils/psVaultUtils.psm1
+++ b/psVaultUtils/psVaultUtils.psm1
@@ -46,4 +46,8 @@ Export-ModuleMember `
         'Renew-VaultToken'
 
         'List-VaultPolicy'
+
+
+        'List-VaultKVSecret'
+        'List-VaultTokenAccessor'
     )

--- a/psVaultUtils/psVaultUtils.psm1
+++ b/psVaultUtils/psVaultUtils.psm1
@@ -47,7 +47,6 @@ Export-ModuleMember `
 
         'List-VaultPolicy'
 
-
         'List-VaultKVSecret'
         'List-VaultTokenAccessor'
     )


### PR DESCRIPTION
# PR Summary

This PR adds support for functions that query Vault API endpoints that utilize the LIST REST method. 
This method is not officially supported in PowerShell 5.1 (-CustomMethod parameter is introduced to Invoke-RestMethod in PowerShell Core 6.0.0

Functions included in this PR are:
  * Adds `Show-VaultTokenAccessor`, a command that lists all active token accessors.
  * Adds `Show-VaultKVSecret`, a command that presents a list of key names at a specified Vault secret path.

## Context

These set of changes are a feature enhancement that improve/extend the module's functionality.

## Changes

* Adds support for functions that query Vault API endpoints that utilize the LIST method.
  * Adds Show-VaultTokenAccessor, a command that lists all active token accessors.
  * Adds Show-VaultKVSecret, a command that presents a list of key names at a specified Vault secret path.
* Updates the README with information noting the Invoke-RestMethod limitation of not having a LIST method.
* Updates the README with information about the Show --> List aliasing.
* Updates the module manifest with new functions and aliases.
* Fixes a bug in Format-VaultOutput introduced in v1.5.1.
